### PR TITLE
Update workflows to use fully qualified URLs for test data

### DIFF
--- a/bam-to-unmapped-bams.inputs.json
+++ b/bam-to-unmapped-bams.inputs.json
@@ -1,5 +1,3 @@
-
 {
-  "BamToUnmappedBams.input_bam": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/NA12878.bam"
+  "BamToUnmappedBams.input_bam": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/NA12878.bam?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
 }
-

--- a/cram-to-bam.inputs.json
+++ b/cram-to-bam.inputs.json
@@ -1,8 +1,8 @@
 {
   "CramToBamFlow.sample_name": "NA12878",
-  "CramToBamFlow.input_cram": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/NA12878.cram",
-  
-  "CramToBamFlow.ref_dict": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict",
-  "CramToBamFlow.ref_fasta": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta",
-  "CramToBamFlow.ref_fasta_index": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+  "CramToBamFlow.input_cram": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/NA12878.cram?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D",
+
+  "CramToBamFlow.ref_dict": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D",
+  "CramToBamFlow.ref_fasta": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D",
+  "CramToBamFlow.ref_fasta_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
 }

--- a/interleaved-fastq-to-paired-fastq.inputs.json
+++ b/interleaved-fastq-to-paired-fastq.inputs.json
@@ -1,3 +1,3 @@
 {
-  "UninterleaveFastqs.input_fastq": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
+  "UninterleaveFastqs.input_fastq": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
 }

--- a/paired-fastq-to-unmapped-bam.inputs.json
+++ b/paired-fastq-to-unmapped-bam.inputs.json
@@ -1,13 +1,13 @@
 {
   "ConvertPairedFastQsToUnmappedBamWf.readgroup_name": "NA12878_A",
   "ConvertPairedFastQsToUnmappedBamWf.sample_name": "NA12878",
-  "ConvertPairedFastQsToUnmappedBamWf.fastq_1": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_1.fastq",
-  "ConvertPairedFastQsToUnmappedBamWf.fastq_2": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_2.fastq", 
+  "ConvertPairedFastQsToUnmappedBamWf.fastq_1": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_1.fastq?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D",
+  "ConvertPairedFastQsToUnmappedBamWf.fastq_2": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_2.fastq?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D",
   "ConvertPairedFastQsToUnmappedBamWf.library_name": "Solexa-NA12878",
   "ConvertPairedFastQsToUnmappedBamWf.platform_unit": "H06HDADXX130110.2.ATCACGAT",
   "ConvertPairedFastQsToUnmappedBamWf.run_date": "2016-09-01T02:00:00+0200",
   "ConvertPairedFastQsToUnmappedBamWf.platform_name": "illumina",
   "ConvertPairedFastQsToUnmappedBamWf.sequencing_center": "BI",
 
-  "ConvertPairedFastQsToUnmappedBamWf.make_fofn": true  
+  "ConvertPairedFastQsToUnmappedBamWf.make_fofn": true
 }


### PR DESCRIPTION
CoA does not currently support the "/storageAccountName" format for the `datasettestinputs` since it requires cross-cloud `blob-csi-driver` support (which is currently undocumented how to workaround)

This PR simply fully qualifies the URLs.  It has no functional impact of the workflows.