### PR TITLE
Retain access to datasettestinputs

### DIFF
--- a/cram-to-bam.inputs.json
+++ b/cram-to-bam.inputs.json
@@ -1,8 +1,8 @@
 {
   "CramToBamFlow.sample_name": "NA12878",
-  "CramToBamFlow.input_cram": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/NA12878.cram",
+  "CramToBamFlow.input_cram": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/NA12878.cram",
   
-  "CramToBamFlow.ref_dict": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict",
-  "CramToBamFlow.ref_fasta": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta",
-  "CramToBamFlow.ref_fasta_index": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+  "CramToBamFlow.ref_dict": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "CramToBamFlow.ref_fasta": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "CramToBamFlow.ref_fasta_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
 }

--- a/cram-to-bam.trigger.json
+++ b/cram-to-bam.trigger.json
@@ -1,6 +1,6 @@
 {
-  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/cram-to-bam.wdl",
-  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/cram-to-bam.inputs.json",
+  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/cram-to-bam.wdl",
+  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/cram-to-bam.inputs.json",
   "WorkflowOptionsUrl": null,
   "WorkflowDependenciesUrl": null
 }

--- a/interleaved-fastq-to-paired-fastq.inputs.json
+++ b/interleaved-fastq-to-paired-fastq.inputs.json
@@ -1,3 +1,3 @@
 {
-  "UninterleaveFastqs.input_fastq": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
+  "UninterleaveFastqs.input_fastq": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
 }

--- a/interleaved-fastq-to-paired-fastq.trigger.json
+++ b/interleaved-fastq-to-paired-fastq.trigger.json
@@ -1,6 +1,6 @@
 {
-  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/interleaved-fastq-to-paired-fastq.wdl",
-  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/interleaved-fastq-to-paired-fastq.inputs.json",
+  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/interleaved-fastq-to-paired-fastq.wdl",
+  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/interleaved-fastq-to-paired-fastq.inputs.json",
   "WorkflowOptionsUrl": null,
   "WorkflowDependenciesUrl": null
 }

--- a/paired-fastq-to-unmapped-bam.inputs.json
+++ b/paired-fastq-to-unmapped-bam.inputs.json
@@ -1,8 +1,8 @@
 {
   "ConvertPairedFastQsToUnmappedBamWf.readgroup_name": "NA12878_A",
   "ConvertPairedFastQsToUnmappedBamWf.sample_name": "NA12878",
-  "ConvertPairedFastQsToUnmappedBamWf.fastq_1": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_1.fastq",
-  "ConvertPairedFastQsToUnmappedBamWf.fastq_2": "/datasettestinputs/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_2.fastq", 
+  "ConvertPairedFastQsToUnmappedBamWf.fastq_1": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_1.fastq",
+  "ConvertPairedFastQsToUnmappedBamWf.fastq_2": "https://datasettestinputs.blob.core.windows.net/dataset/seq-format-conversion/NA12878_20k/H06HDADXX130110.1.ATCACGAT.20k_reads_2.fastq",
   "ConvertPairedFastQsToUnmappedBamWf.library_name": "Solexa-NA12878",
   "ConvertPairedFastQsToUnmappedBamWf.platform_unit": "H06HDADXX130110.2.ATCACGAT",
   "ConvertPairedFastQsToUnmappedBamWf.run_date": "2016-09-01T02:00:00+0200",

--- a/paired-fastq-to-unmapped-bam.trigger.json
+++ b/paired-fastq-to-unmapped-bam.trigger.json
@@ -1,6 +1,6 @@
 {
-  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/paired-fastq-to-unmapped-bam.wdl",
-  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/az3.0.0/paired-fastq-to-unmapped-bam.inputs.json",
+  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/paired-fastq-to-unmapped-bam.wdl",
+  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/seq-format-conversion-azure/main-azure/paired-fastq-to-unmapped-bam.inputs.json",
   "WorkflowOptionsUrl": null,
   "WorkflowDependenciesUrl": null
 }


### PR DESCRIPTION
`datasettestinputs`'s `dataset` container is now readable anonymously, and thus cannot be mounted on AKS. This works around that limitation.